### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/myhome.yml
+++ b/.github/workflows/myhome.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Publish new MyHome-Schedule version
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: docker.pkg.github.com
           name: docker.pkg.github.com/theofilis/MyHome-Schedule


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore